### PR TITLE
+ feat: support image embedding via ![alt](path) in story/bug create

### DIFF
--- a/skills/zentao-cli/SKILL.md
+++ b/skills/zentao-cli/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Sun Hao <sunhao@chandao.com>
   repository: https://github.com/easysoft/zentao-cli.git
   keywords: [zentao, 禅道, cli, project-management]
-  version: 0.1.7
+  version: 0.1.8
 ---
 
 # 禅道 CLI
@@ -65,6 +65,17 @@ zentao login -s https://zentao.example.com -u admin -p 123456
 | 帮助 | `zentao <module> help` |
 
 也支持 `--data='JSON'` 传入 JSON 数据。
+
+### 图片嵌入
+
+创建 story/bug 时，内容字段（`--spec`、`--verify`、`--steps`）支持 `![描述](本地路径)` 语法引用本地图片，CLI 会自动上传到禅道并替换为图片链接：
+
+```bash
+zentao story create --productID=1 --title="带截图的需求" \
+  --spec='界面问题 ![截图](/tmp/screenshot.png) 如上图所示'
+```
+
+支持绝对路径、`~` 路径和相对路径（相对于当前工作目录）。
 
 ## 模块与操作速查
 
@@ -258,6 +269,7 @@ zentao help              # 查看所有命令
 | E2002 | 对象不存在 | 检查 ID 是否正确 |
 | E2003 | 缺少必要参数 | 执行 `zentao <module> help` 或 `zentao <module> <action> help` 查看操作参数 |
 | E2006 | 无权限 | 提示用户检查权限 |
+| E2011 | 图片文件不存在 | 检查 `![描述](路径)` 中的文件路径是否正确 |
 | E5001 | 请求超时 | 检查网络或禅道服务状态 |
 
 ## 注意事项

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,6 +24,7 @@ export const ERROR_CODES = {
     E2008: '禅道服务端返回错误（Url：{url}，Status：{status}），请查看详细错误信息：{serverResponse}',
     E2009: '选项 {option} 的值无效，{reason}',
     E2010: '选项 {option} 的值类型必须为 {type}，实际类型为 {actualType}',
+    E2011: '图片文件不存在或不是文件：{path}（解析后：{resolved}）',
 
     // 数据处理 (30xx)
     E3001: '`--pick` 指定的字段不存在',

--- a/src/modules/executor.ts
+++ b/src/modules/executor.ts
@@ -14,6 +14,73 @@ import { convertHtmlFields, convertHtmlFieldsInArray } from '../utils/html.js';
 import { buildParams, normalizeActionName } from './args.js';
 import { getAction } from './helper.js';
 import { ZentaoError } from '../errors.js';
+import { processImagesInContent, hasImageMarkers } from '../utils/images.js';
+
+/** 支持图片标记的内容字段。 */
+const IMAGE_CONTENT_FIELDS: Record<string, string[]> = {
+    story: ['spec', 'verify'],
+    bug: ['steps'],
+};
+
+/**
+ * 在创建 story/bug 时，处理内容字段中的图片标记。
+ *
+ * 解析 `![alt](path)` 标记，上传本地图片到禅道，并将标记替换为禅道图片引用格式。
+ */
+async function processImagesForCreate(
+    client: ZentaoClient,
+    moduleName: string,
+    params: Record<string, unknown>,
+    options: ModuleActionOptions,
+): Promise<Record<string, unknown>> {
+    const fields = IMAGE_CONTENT_FIELDS[moduleName];
+    if (!fields) return params;
+
+    const dataObject = typeof params.data === 'string'
+        ? JSON.parse(params.data) as Record<string, unknown>
+        : (params.data as Record<string, unknown> | undefined);
+
+    const hasImages = fields.some((field) => {
+        const direct = params[field];
+        if (typeof direct === 'string' && hasImageMarkers(direct)) return true;
+        if (dataObject) {
+            const nested = dataObject[field];
+            return typeof nested === 'string' && hasImageMarkers(nested);
+        }
+        return false;
+    });
+    if (!hasImages) return params;
+
+    const result = { ...params };
+    let resultData = dataObject ? { ...dataObject } : undefined;
+    let dataChanged = false;
+
+    for (const field of fields) {
+        const direct = result[field];
+        if (typeof direct === 'string' && hasImageMarkers(direct)) {
+            result[field] = await processImagesInContent(client, direct, {
+                verbose: options.format !== 'json' && options.format !== 'raw',
+                objectType: moduleName,
+            });
+            continue;
+        }
+        if (resultData) {
+            const nested = resultData[field];
+            if (typeof nested === 'string' && hasImageMarkers(nested)) {
+                resultData[field] = await processImagesInContent(client, nested, {
+                    verbose: options.format !== 'json' && options.format !== 'raw',
+                    objectType: moduleName,
+                });
+                dataChanged = true;
+            }
+        }
+    }
+
+    if (dataChanged && resultData) {
+        result.data = JSON.stringify(resultData);
+    }
+    return result;
+}
 
 export interface ModuleExecutionResult {
     /** 解析到的动作定义 */
@@ -56,13 +123,19 @@ export async function executeModuleCommand(
     }
 
     const params = buildParams(options, actionName, args);
-    const requestName = `${module.name}/${normalizeActionName(actionName)}`;
+    const normalizedActionName = normalizeActionName(actionName);
+    const requestName = `${module.name}/${normalizedActionName}`;
+
+    // 创建 story/bug 时，处理内容字段中的图片标记
+    const processedParams = normalizedActionName === 'create'
+        ? await processImagesForCreate(client, module.name, params, options)
+        : params;
 
     let response;
     try {
         // 注意：不向 request() 传递 filter/search/sort/limit/pick，
         // 以保留 CLI 自身的数据处理语义（在下方本地后处理）。
-        response = await request(requestName, params, {
+        response = await request(requestName, processedParams, {
             client,
             autoFill: action.type === 'update',
             throwOnFail: true,

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,0 +1,126 @@
+import type { ZentaoClient } from '../api/index.js';
+import { uploadFile, type UploadedFile } from 'zentao-api';
+import { resolve } from 'node:path';
+import { existsSync, lstatSync } from 'node:fs';
+import { ZentaoError } from '../errors.js';
+
+/** 图片标记正则：匹配 ![alt](path) 格式。 */
+const IMAGE_MARKER_RE = /!\[([^\]]*)\]\(([^)]+)\)/g;
+/** 图片标记正则（无 g 标志，用于 test 检测）。 */
+const IMAGE_MARKER_RE_TEST = /!\[([^\]]*)\]\(([^)]+)\)/;
+
+/** 解析出的图片标记。 */
+export interface ImageMarker {
+  /** 完整原始标记文本。 */
+  fullMatch: string;
+  /** 图片描述。 */
+  alt: string;
+  /** 本地文件路径。 */
+  path: string;
+  /** 在原文中的起始位置。 */
+  index: number;
+}
+
+/**
+ * 从内容文本中解析所有图片标记。
+ *
+ * @param content - 包含图片标记的内容文本。 * @returns 解析出的图片标记列表。
+ */
+export function parseImageMarkers(content: string): ImageMarker[] {
+  const markers: ImageMarker[] = [];
+  if (!content) return markers;
+
+  for (const match of content.matchAll(IMAGE_MARKER_RE)) {
+    const [fullMatch, alt, path] = match;
+    if (fullMatch === undefined || alt === undefined || path === undefined) continue;
+    markers.push({
+      fullMatch,
+      alt,
+      path,
+      index: match.index ?? 0,
+    });
+  }
+  return markers;
+}
+
+/**
+ * 判断内容中是否包含图片标记。
+ *
+ * @param content - 内容文本。
+ * @returns 是否包含图片标记。
+ */
+export function hasImageMarkers(content: string): boolean {
+  if (!content) return false;
+  return IMAGE_MARKER_RE_TEST.test(content);
+}
+/**
+ * 解析图片标记中的路径为绝对路径。
+ *
+ * @param rawPath - 标记中的原始路径。
+ * @param baseDir - 解析相对路径时的基准目录。
+ * @returns 绝对路径。
+ */
+export function resolveImagePath(rawPath: string, baseDir: string): string {
+  if (rawPath.startsWith('/')) return rawPath;
+  if (rawPath.startsWith('~')) {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    return rawPath.replace(/^~/, home);
+  }
+  return resolve(baseDir, rawPath);
+}
+
+/** 上传图片并替换内容中的标记。 */
+export interface ProcessImageOptions {
+  /** 解析相对路径时的基准目录。 */
+  baseDir?: string;
+  /** 是否显示上传进度。 */
+  verbose?: boolean;
+  /** 关联的对象类型（如 story、bug），上传时传给禅道。 */
+  objectType?: string;
+}
+
+/**
+ * 上传内容中所有图片标记引用的本地文件，并将标记替换为禅道图片引用格式。
+ *
+ * @param client - 已认证的 ZentaoClient 实例。
+ * @param content - 包含图片标记的内容文本。
+ * @param options - 处理选项。
+ * @returns 替换后的内容文本。
+ */
+export async function processImagesInContent(
+  client: ZentaoClient,
+  content: string,
+  options: ProcessImageOptions = {},
+): Promise<string> {
+  const markers = parseImageMarkers(content);
+  if (markers.length === 0) return content;
+
+  const baseDir = options.baseDir ?? process.cwd();
+  let result = content;
+  const uploadCache = new Map<string, UploadedFile>();
+
+  for (const marker of markers) {
+    const absPath = resolveImagePath(marker.path, baseDir);
+
+    if (!existsSync(absPath) || !lstatSync(absPath).isFile()) {
+      throw new ZentaoError('E2011', { path: marker.path, resolved: absPath });
+    }
+
+    let uploaded = uploadCache.get(absPath);
+    if (!uploaded) {
+      if (options.verbose) {
+        console.error(`上传图片: ${absPath}`);
+      }
+      uploaded = await uploadFile(client, absPath, {
+        objectType: options.objectType,
+        objectID: 0,
+      });
+      uploadCache.set(absPath, uploaded);
+    }
+
+    const replacement = `<img src="${uploaded.url}" alt="${marker.alt}" />`;
+    result = result.replace(marker.fullMatch, replacement);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Changes

- Add `src/utils/images.ts`: parse `![alt](path)` markers, resolve paths (absolute/relative/~), upload via SDK `uploadFile`, replace with `<img>` tags
- Integrate image processing in `executor.ts` for story/bug create actions (`--spec`, `--verify`, `--steps`)
- Support `--data` JSON format with embedded image markers
- Add `E2011` error code for missing image files
- Update SKILL.md (v0.1.8): document image embedding feature

## Depends on

- easysoft/zentao-api: `uploadFile` export (feat/image-upload branch)

## Testing (9/9 pass)

| Case | Result |
|------|--------|
| story --spec single image (abs path) | PASS |
| story --verify image | PASS |
| bug --steps image | PASS |
| Multiple images in one field | PASS |
| Relative + ~ path resolution | PASS |
| Non-existent file -> E2011 | PASS |
| --data JSON with images | PASS |
| Same image twice (cache dedup) | PASS |
| No image markers (unaffected) | PASS |