### PR TITLE
* fix: reuse auth profile in read-only environments

### DIFF
--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -27,7 +27,12 @@ export async function ensureAuth(options?: { insecure?: boolean; timeout?: numbe
             timeout: options?.timeout ?? config.timeout,
         };
         currentProfile.lastUsedTime = new Date().toISOString();
-        saveProfile(currentProfile);
+        try {
+            saveProfile(currentProfile);
+        } catch {
+            // Updating usage metadata is best-effort and must not invalidate an
+            // otherwise usable token in a read-only environment.
+        }
         return {
             client: createClient(currentProfile.server, currentProfile.token, clientOpts),
             profile: currentProfile,

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -19,7 +19,9 @@ let store: Configstore | null = null;
 
 function getStore(): Configstore {
     if (!store) {
-        store = new Configstore('zentao-cli', {}, { configPath });
+        // Passing an empty defaults object makes Configstore rewrite the file in
+        // its constructor. Reads must remain usable in read-only environments.
+        store = new Configstore('zentao-cli', undefined, { configPath });
         enforcePermissions();
     }
     return store;

--- a/tests/auth-flow.test.ts
+++ b/tests/auth-flow.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureAuth } from '../src/auth/flow';
+import {
+    __resetConfigStoreForTests,
+    profileKey,
+    setConfigPath,
+} from '../src/config/store';
+import { mockProfile } from './helpers';
+
+describe('ensureAuth', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        __resetConfigStoreForTests();
+        tempDir = mkdtempSync(join(tmpdir(), 'zentao-cli-auth-readonly-'));
+        const configPath = join(tempDir, 'config.json');
+        writeFileSync(configPath, JSON.stringify({
+            currentProfile: profileKey(mockProfile.account, mockProfile.server),
+            profiles: [mockProfile],
+        }));
+        chmodSync(tempDir, 0o500);
+        setConfigPath(configPath);
+    });
+
+    afterEach(() => {
+        __resetConfigStoreForTests();
+        chmodSync(tempDir, 0o700);
+        rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('reuses a valid token when last-used persistence is not writable', async () => {
+        const auth = await ensureAuth();
+
+        expect(auth.profile.account).toBe('admin');
+        expect(auth.profile.token).toBe('test-token');
+    });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { homedir, tmpdir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { DEFAULT_CONFIG, VALID_CONFIG_KEYS } from '../src/config/defaults';
 import {
     getConfigPath,
@@ -309,6 +309,36 @@ describe('profile management', () => {
         saveProfile({ ...mockProfile, token: 'new-token' });
         expect(getAllProfiles().length).toBe(1);
         expect(getCurrentProfile()!.token).toBe('new-token');
+    });
+});
+
+describe('read-only profile storage', () => {
+    let tempDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        resetConfigStore();
+        tempDir = mkdtempSync(join(tmpdir(), 'zentao-cli-readonly-'));
+        configPath = join(tempDir, 'config.json');
+        writeFileSync(configPath, JSON.stringify({
+            currentProfile: profileKey(mockProfile.account, mockProfile.server),
+            profiles: [mockProfile],
+        }));
+        chmodSync(tempDir, 0o500);
+        setConfigPath(configPath);
+    });
+
+    afterEach(() => {
+        resetConfigStore();
+        chmodSync(tempDir, 0o700);
+        rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('getCurrentProfile does not rewrite an existing config file', () => {
+        const current = getCurrentProfile();
+
+        expect(current?.account).toBe('admin');
+        expect(current?.token).toBe('test-token');
     });
 });
 


### PR DESCRIPTION
## Summary

- avoid rewriting an existing profile config when the store is initialized for reads
- treat `lastUsedTime` persistence as best-effort so a valid token remains usable when profile storage is read-only
- add regression coverage for both read paths

## Root cause

`Configstore` received an empty defaults object, which rewrote the config during construction. In addition, `ensureAuth()` always persisted `lastUsedTime`. In sandboxed or otherwise read-only environments, either write failed and the CLI surfaced `E1005`, even though the stored token was valid.

## Verification

- `bun test` — 186 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- installed the packed CLI locally and confirmed `zentao --version` and an authenticated `zentao story 326 --format=json` both reuse the existing token without another login
